### PR TITLE
Adds `CITATION.cff` file and supporting test files

### DIFF
--- a/.github/workflows/validate-cff.yml
+++ b/.github/workflows/validate-cff.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    paths:
+      - CITATION.cff
+  workflow_dispatch:
+
+name: CITATION.cff
+jobs:
+  Validate-CITATION-cff:
+    runs-on: ubuntu-latest
+    name: Validate CITATION.cff
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Validate CITATION.cff
+        uses: dieghernan/cff-validator@v3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,8 +17,8 @@ authors:
   - given-names: Hind
     family-names: Zantout
     email: h.zantout@hw.ac.uk
-  - given-names: Michael
-    family-names: A Lones
+  - given-names: Michael A.
+    family-names: Lones
     email: m.lones@hw.ac.uk
 identifiers:
   - type: doi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,45 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: DroidDissector
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Ali
+    family-names: Muzaffar
+    email: am29@hw.ac.uk
+  - given-names: Hani Ragab
+    family-names: Hassen
+    email: h.ragabhassen@hw.ac.uk
+  - given-names: Hind
+    family-names: Zantout
+    email: h.zantout@hw.ac.uk
+  - given-names: Michael
+    family-names: A Lones
+    email: m.lones@hw.ac.uk
+identifiers:
+  - type: doi
+    value: 10.48550/arXiv.2308.04170
+    description: v2
+  - type: url
+    value: 'https://arxiv.org/abs/2308.04170'
+repository-code: >-
+  https://github.com/alisolehria/DroidDissector-A-Static-and-Dynamic-Analysis-Tool-for-Android-Malware-Detection
+abstract: >
+  DroidDissector is an extraction tool for both static and
+  dynamic features. The aim is to provide Android malware
+  researchers and analysts with an integrated tool that can
+  extract all of the most widely used features in Android
+  malware detection from one location. The static analysis
+  module extracts features from both the manifest file and
+  the source code of the application to obtain a broad array
+  of features that include permissions, API call graphs and
+  opcodes. The dynamic analysis module runs on the latest
+  version of Android and analyses the complete behaviour of
+  an application by tracking the system calls used, network
+  traffic generated, API calls used and log files produced
+  by the application.
+version: v2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,10 +22,9 @@ authors:
     email: m.lones@hw.ac.uk
 identifiers:
   - type: doi
-    value: 10.48550/arXiv.2308.04170
-    description: v2
+    value: 10.1007/978-3-031-40598-3_1
   - type: url
-    value: 'https://arxiv.org/abs/2308.04170'
+    value: 'https://doi.org/10.1007/978-3-031-40598-3_1'
 repository-code: >-
   https://github.com/alisolehria/DroidDissector-A-Static-and-Dynamic-Analysis-Tool-for-Android-Malware-Detection
 abstract: >

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DroidDissector: A Static and Dynamic Analysis Tool for Android Malware Detection
 
+[![arXiv](https://img.shields.io/badge/arXiv-2308.04170-b31b1b.svg)](https://arxiv.org/abs/2308.04170)
+
 A static and dynamic analysis tool for Android malware detection. 
 Please cite the paper below if you use this tool:
 * Muzaffar, A., Hassen, H. R., Zantout, H., & Lones, M. A. (2023). DroidDissector: A Static and Dynamic Analysis Tool for Android Malware Detection. arXiv preprint arXiv:2308.04170.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install -r requirements_dynamic.txt
 
 * Emulator has root access.
 * Emulator is connected to your network and adb. 
-* Copy the FRIDA server file in "api_calls" folder to the emulator in this location: "/data/local/tmp/".
+* Copy the FRIDA server file in [**`api_calls`**](./api_calls/) folder to the emulator in this location: **`/data/local/tmp/`**.
 * Create a snapshot of the emulator image. This image will be used to run dynamic analysis on each application. 
 
 ## .env


### PR DESCRIPTION
This PR adds the `CITATION.cff` file, which provides the referencing metadata for software in a plaintext manner that makes it easy to cite the software and download it where possible.

Also a new button appears on the sidebar where users can Cite the Repository easily.
<img width="30%" alt="Cite the Repository" src="https://github.com/alisolehria/DroidDissector-A-Static-and-Dynamic-Analysis-Tool-for-Android-Malware-Detection/assets/73425927/60869736-1bbd-4252-8fa2-1a40257b26fd">

It is even officially supported by [Zenedo](https://twitter.com/ZENODO_ORG/status/1420357001490706442) and [Zotero](https://twitter.com/zotero/status/1420515377390530560) 

It also adds supporting tests where it ensures that the `CITATION.cff` file is in the correct structure.
Feel free to add any other supporting tests where needed.

Reference: 
- [Citation File Format - Website](https://citation-file-format.github.io/)
- [cff-validator - GitHub Actions](https://github.com/marketplace/actions/cff-validator)
- [cffinit - Easily create your own `CITATION.cff` file](https://citation-file-format.github.io/cff-initializer-javascript/)
- [CITATION files - GitHub Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)